### PR TITLE
Add communication between content and background scripts

### DIFF
--- a/src/ext/background.js
+++ b/src/ext/background.js
@@ -1,0 +1,1 @@
+console.log('background running!');

--- a/src/ext/background.js
+++ b/src/ext/background.js
@@ -1,1 +1,7 @@
 console.log('background running!');
+
+chrome.runtime.onMessage.addListener(receiver);
+
+function receiver(req, sender, sendResponse) {
+  console.log(req);
+}

--- a/src/ext/inject.js
+++ b/src/ext/inject.js
@@ -8,8 +8,8 @@ window.addEventListener("message", function(event) {
     console.log('message', message);
   }
 
-  chrome.runtime.sendMessage({message});
-})
+  chrome.runtime.sendMessage(message);
+});
 
 // Example call from webpage:
 // window.postMessage({type: "FROM_PAGE", method: "transfer", payee: "0x0", amount: "100"}, "*");

--- a/src/ext/manifest.json
+++ b/src/ext/manifest.json
@@ -18,5 +18,8 @@
       "js": ["inject.js"]
     }
   ],
+  "background": {
+    "scripts": ["background.js"]
+  },
     "manifest_version": 2
   }


### PR DESCRIPTION
Done:
- webpage can emit event to content script
- content script can route info about event call to the background script
Todo:
- background script opens up popup on event
- background script gives event info to popup
- popup prepopulates transfer page with info
- object abstraction of events that webpages can use